### PR TITLE
fritzcap: fix FRITZ!Box Username argument not working

### DIFF
--- a/fritzcap.sh
+++ b/fritzcap.sh
@@ -40,7 +40,7 @@ while [ "$1" != "" ]; do
 			FRITZ_IP=$2
             shift
             ;;
-        --user)
+        --username)
 			FRITZ_USER=$2
             shift
             ;;


### PR DESCRIPTION
When I updated to FRITZ!OS 7.24 beta on my 4040, I noticed this script stopped working, and the error of unrecognised argument kept showing up when trying to use a username (it seems 7.24 made me a username for the router; I can see it on the login page) as the script used `--username` for the argument from the UI, and set `--user` (empty)'s value to $FRITZ_USER